### PR TITLE
Clean wrapped lines when generating TXT

### DIFF
--- a/PDFReader.xcodeproj/project.pbxproj
+++ b/PDFReader.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A1B2C3D4E5F6000000000106 /* ProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000206 /* ProgressStore.swift */; };
 		A1B2C3D4E5F6000000000107 /* ReaderPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000207 /* ReaderPreferencesStore.swift */; };
 		A1B2C3D4E5F6000000000108 /* BookLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000208 /* BookLibrary.swift */; };
+		A1B2C3D4E5F6000000000113 /* TextCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000214 /* TextCleaner.swift */; };
 		A1B2C3D4E5F6000000000112 /* PDFTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000213 /* PDFTextExtractor.swift */; };
 		A1B2C3D4E5F6000000000111 /* TextPageFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000212 /* TextPageFile.swift */; };
 		A1B2C3D4E5F6000000000109 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000209 /* LibraryView.swift */; };
@@ -23,10 +24,22 @@
 		A1B2C3D4E5F600000000010D /* TextPageReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000020D /* TextPageReaderView.swift */; };
 		A1B2C3D4E5F600000000010E /* ReaderQuickMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000020E /* ReaderQuickMenu.swift */; };
 		A1B2C3D4E5F600000000010F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000020F /* Assets.xcassets */; };
+		A1B2C3D4E5F6000000000114 /* TextCleanerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000000000215 /* TextCleanerTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A1B2C3D4E5F600000000000E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A1B2C3D4E5F6000000000008 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A1B2C3D4E5F6000000000001;
+			remoteInfo = PDFReader;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		A1B2C3D4E5F6000000000002 /* PDFReader.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PDFReader.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B2C3D4E5F6000000000009 /* PDFReaderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PDFReaderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D4E5F6000000000201 /* PDFReaderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderApp.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000202 /* PDFBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBook.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000203 /* ReadingProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingProgress.swift; sourceTree = "<group>"; };
@@ -35,6 +48,7 @@
 		A1B2C3D4E5F6000000000206 /* ProgressStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressStore.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000207 /* ReaderPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPreferencesStore.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000208 /* BookLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookLibrary.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6000000000214 /* TextCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleaner.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000213 /* PDFTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFTextExtractor.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000212 /* TextPageFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPageFile.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000209 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
@@ -44,10 +58,18 @@
 		A1B2C3D4E5F600000000020E /* ReaderQuickMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderQuickMenu.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F600000000020F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000000000210 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1B2C3D4E5F6000000000215 /* TextCleanerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		A1B2C3D4E5F6000000000004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F600000000000C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -61,6 +83,7 @@
 			isa = PBXGroup;
 			children = (
 				A1B2C3D4E5F6000000000301 /* PDFReader */,
+				A1B2C3D4E5F6000000000310 /* PDFReaderTests */,
 				A1B2C3D4E5F6000000000006 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -69,6 +92,7 @@
 			isa = PBXGroup;
 			children = (
 				A1B2C3D4E5F6000000000002 /* PDFReader.app */,
+				A1B2C3D4E5F6000000000009 /* PDFReaderTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -103,6 +127,7 @@
 				A1B2C3D4E5F6000000000206 /* ProgressStore.swift */,
 				A1B2C3D4E5F6000000000207 /* ReaderPreferencesStore.swift */,
 				A1B2C3D4E5F6000000000208 /* BookLibrary.swift */,
+				A1B2C3D4E5F6000000000214 /* TextCleaner.swift */,
 				A1B2C3D4E5F6000000000213 /* PDFTextExtractor.swift */,
 				A1B2C3D4E5F6000000000212 /* TextPageFile.swift */,
 			);
@@ -129,6 +154,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		A1B2C3D4E5F6000000000310 /* PDFReaderTests */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D4E5F6000000000215 /* TextCleanerTests.swift */,
+			);
+			path = PDFReaderTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -149,6 +182,24 @@
 			productReference = A1B2C3D4E5F6000000000002 /* PDFReader.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A1B2C3D4E5F600000000000A /* PDFReaderTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1B2C3D4E5F6000000000608 /* Build configuration list for PBXNativeTarget "PDFReaderTests" */;
+			buildPhases = (
+				A1B2C3D4E5F600000000000B /* Sources */,
+				A1B2C3D4E5F600000000000C /* Frameworks */,
+				A1B2C3D4E5F600000000000D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1B2C3D4E5F600000000000F /* PBXTargetDependency */,
+			);
+			name = PDFReaderTests;
+			productName = PDFReaderTests;
+			productReference = A1B2C3D4E5F6000000000009 /* PDFReaderTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -161,6 +212,10 @@
 				TargetAttributes = {
 					A1B2C3D4E5F6000000000001 = {
 						CreatedOnToolsVersion = 16.2;
+					};
+					A1B2C3D4E5F600000000000A = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = A1B2C3D4E5F6000000000001;
 					};
 				};
 			};
@@ -178,6 +233,7 @@
 			projectRoot = "";
 			targets = (
 				A1B2C3D4E5F6000000000001 /* PDFReader */,
+				A1B2C3D4E5F600000000000A /* PDFReaderTests */,
 			);
 		};
 /* End PBXProject section */
@@ -188,6 +244,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A1B2C3D4E5F600000000010F /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F600000000000D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,6 +269,7 @@
 				A1B2C3D4E5F6000000000106 /* ProgressStore.swift in Sources */,
 				A1B2C3D4E5F6000000000107 /* ReaderPreferencesStore.swift in Sources */,
 				A1B2C3D4E5F6000000000108 /* BookLibrary.swift in Sources */,
+				A1B2C3D4E5F6000000000113 /* TextCleaner.swift in Sources */,
 				A1B2C3D4E5F6000000000112 /* PDFTextExtractor.swift in Sources */,
 				A1B2C3D4E5F6000000000111 /* TextPageFile.swift in Sources */,
 				A1B2C3D4E5F6000000000109 /* LibraryView.swift in Sources */,
@@ -216,7 +280,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A1B2C3D4E5F600000000000B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B2C3D4E5F6000000000114 /* TextCleanerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A1B2C3D4E5F600000000000F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A1B2C3D4E5F6000000000001 /* PDFReader */;
+			targetProxy = A1B2C3D4E5F600000000000E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		A1B2C3D4E5F6000000000601 /* Debug */ = {
@@ -390,6 +470,56 @@
 			};
 			name = Release;
 		};
+		A1B2C3D4E5F6000000000606 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3J5E46N9MV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sean.pdfreaderTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PDFReader.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PDFReader";
+			};
+			name = Debug;
+		};
+		A1B2C3D4E5F6000000000607 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3J5E46N9MV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sean.pdfreaderTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PDFReader.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PDFReader";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -407,6 +537,15 @@
 			buildConfigurations = (
 				A1B2C3D4E5F6000000000604 /* Debug */,
 				A1B2C3D4E5F6000000000605 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1B2C3D4E5F6000000000608 /* Build configuration list for PBXNativeTarget "PDFReaderTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1B2C3D4E5F6000000000606 /* Debug */,
+				A1B2C3D4E5F6000000000607 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PDFReader.xcodeproj/xcshareddata/xcschemes/PDFReader.xcscheme
+++ b/PDFReader.xcodeproj/xcshareddata/xcschemes/PDFReader.xcscheme
@@ -9,6 +9,20 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F600000000000A"
+               BuildableName = "PDFReaderTests.xctest"
+               BlueprintName = "PDFReaderTests"
+               ReferencedContainer = "container:PDFReader.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
@@ -28,6 +42,19 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F600000000000A"
+               BuildableName = "PDFReaderTests.xctest"
+               BlueprintName = "PDFReaderTests"
+               ReferencedContainer = "container:PDFReader.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/PDFReader/Services/PDFTextExtractor.swift
+++ b/PDFReader/Services/PDFTextExtractor.swift
@@ -81,8 +81,8 @@ enum PDFTextExtractor {
                         try Task.checkCancellation()
 
                         let extractedText = document.page(at: index)?.string ?? ""
-                        let normalizedText = normalizeChineseParagraphIndents(in: extractedText)
-                        let pageText = normalizedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "此页没有可提取文本" : normalizedText
+                        let cleanedText = TextCleaner.cleanExtractedText(extractedText)
+                        let pageText = cleanedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "此页没有可提取文本" : cleanedText
                         let separator = index == pageCount - 1 ? "" : "\n\u{000C}\n"
 
                         guard let data = (pageText + separator).data(using: .utf8) else {
@@ -111,45 +111,4 @@ enum PDFTextExtractor {
         }.value
     }
 
-    private static func normalizeChineseParagraphIndents(in text: String) -> String {
-        let lineBreakTrimmedText = text.trimmingCharacters(in: .newlines)
-        let lines = lineBreakTrimmedText.split(separator: "\n", omittingEmptySubsequences: false)
-
-        return lines.map { line in
-            var textLine = String(line)
-            if textLine.hasSuffix("\r") {
-                textLine.removeLast()
-            }
-
-            if textLine.hasPrefix("\u{3000}\u{3000}") {
-                return textLine
-            }
-
-            let leadingSpaceCount = textLine.prefix { $0 == " " || $0 == "\t" }.count
-            guard leadingSpaceCount > 0 else {
-                return textLine
-            }
-
-            let contentStart = textLine.index(textLine.startIndex, offsetBy: leadingSpaceCount)
-            let content = textLine[contentStart...]
-            guard content.first?.isLikelyCJK == true else {
-                return textLine
-            }
-
-            return "\u{3000}\u{3000}" + content
-        }.joined(separator: "\n")
-    }
-}
-
-private extension Character {
-    var isLikelyCJK: Bool {
-        unicodeScalars.contains { scalar in
-            switch scalar.value {
-            case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF:
-                return true
-            default:
-                return false
-            }
-        }
-    }
 }

--- a/PDFReader/Services/TextCleaner.swift
+++ b/PDFReader/Services/TextCleaner.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+enum TextCleaner {
+    static func cleanExtractedText(_ text: String) -> String {
+        removeWrappedLineBreaks(in: normalizeChineseParagraphIndents(in: text))
+    }
+
+    static func removeWrappedLineBreaks(in text: String) -> String {
+        let lineBreakTrimmedText = text.trimmingCharacters(in: .newlines)
+        let lines = lineBreakTrimmedText
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { rawLine -> String in
+                var line = String(rawLine)
+                if line.hasSuffix("\r") {
+                    line.removeLast()
+                }
+                return line
+            }
+
+        var mergedLines: [String] = []
+        for line in lines {
+            guard let previousLine = mergedLines.last else {
+                mergedLines.append(line)
+                continue
+            }
+
+            if shouldRemoveLineBreak(previousLine: previousLine, nextLine: line) {
+                mergedLines[mergedLines.count - 1] = previousLine + lineForJoining(line)
+            } else {
+                mergedLines.append(line)
+            }
+        }
+
+        return mergedLines.joined(separator: "\n")
+    }
+
+    static func normalizeChineseParagraphIndents(in text: String) -> String {
+        let lineBreakTrimmedText = text.trimmingCharacters(in: .newlines)
+        let lines = lineBreakTrimmedText.split(separator: "\n", omittingEmptySubsequences: false)
+
+        return lines.map { line in
+            var textLine = String(line)
+            if textLine.hasSuffix("\r") {
+                textLine.removeLast()
+            }
+
+            if textLine.hasPrefix("\u{3000}\u{3000}") {
+                return textLine
+            }
+
+            let leadingSpaceCount = textLine.prefix { $0 == " " || $0 == "\t" }.count
+            guard leadingSpaceCount > 0 else {
+                return textLine
+            }
+
+            let contentStart = textLine.index(textLine.startIndex, offsetBy: leadingSpaceCount)
+            let content = textLine[contentStart...]
+            guard content.first?.isLikelyCJK == true else {
+                return textLine
+            }
+
+            return "\u{3000}\u{3000}" + content
+        }.joined(separator: "\n")
+    }
+
+    private static func shouldRemoveLineBreak(previousLine: String, nextLine: String) -> Bool {
+        if previousLine.trimmingCharacters(in: .whitespaces).isEmpty ||
+            nextLine.trimmingCharacters(in: .whitespaces).isEmpty {
+            return false
+        }
+
+        if previousLine.contains("\u{000C}") || nextLine.contains("\u{000C}") {
+            return false
+        }
+
+        if startsWithLeadingPunctuation(nextLine) {
+            return true
+        }
+
+        if startsWithParagraphIndent(nextLine) {
+            return false
+        }
+
+        return hasSentenceEndingPause(previousLine) == false
+    }
+
+    private static func hasSentenceEndingPause(_ line: String) -> Bool {
+        var trimmedLine = line.trimmingCharacters(in: .whitespaces)
+        while let last = trimmedLine.last, Self.closingPunctuation.contains(last) {
+            trimmedLine.removeLast()
+        }
+
+        guard let last = trimmedLine.last else {
+            return false
+        }
+
+        return Self.sentenceEndingPunctuation.contains(last)
+    }
+
+    private static func startsWithLeadingPunctuation(_ line: String) -> Bool {
+        guard let first = line.firstNonWhitespace else {
+            return false
+        }
+
+        return Self.leadingPunctuation.contains(first)
+    }
+
+    private static func lineForJoining(_ line: String) -> String {
+        startsWithLeadingPunctuation(line) ? line.trimmingLeadingWhitespace() : line
+    }
+
+    private static func startsWithParagraphIndent(_ line: String) -> Bool {
+        line.hasPrefix("\u{3000}\u{3000}") ||
+            line.hasPrefix("  ") ||
+            line.hasPrefix("\t")
+    }
+
+    private static let sentenceEndingPunctuation = Set<Character>(["。", ".", "！", "!", "？", "?", "…"])
+    private static let closingPunctuation = Set<Character>(["”", "\"", "’", "'", "）", ")", "》", ">", "】", "]", "」", "』"])
+    private static let leadingPunctuation = Set<Character>([
+        "，", ",", "。", ".", "！", "!", "？", "?", "；", ";", "：", ":", "、",
+        "”", "\"", "’", "'", "）", ")", "》", ">", "】", "]", "」", "』"
+    ])
+}
+
+private extension Character {
+    var isLikelyCJK: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+private extension String {
+    var firstNonWhitespace: Character? {
+        first { $0 != " " && $0 != "\t" }
+    }
+
+    func trimmingLeadingWhitespace() -> String {
+        guard let firstContentIndex = firstIndex(where: { $0 != " " && $0 != "\t" }) else {
+            return ""
+        }
+
+        return String(self[firstContentIndex...])
+    }
+}

--- a/PDFReaderTests/TextCleanerTests.swift
+++ b/PDFReaderTests/TextCleanerTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import PDFReader
+
+final class TextCleanerTests: XCTestCase {
+    func testJoinsWrappedNarrationLinesFromLordOfMysteriesSample() {
+        let text = """
+        　　光怪陆离满是低语的梦境迅速支离破碎，熟睡中的周明瑞只觉脑
+        袋抽痛异常，仿佛被人用棒子狠狠抡了一下，不，更像是遭尖锐的物
+        品刺入太阳穴并伴随有搅动!
+        """
+
+        XCTAssertEqual(
+            TextCleaner.cleanExtractedText(text),
+            "　　光怪陆离满是低语的梦境迅速支离破碎，熟睡中的周明瑞只觉脑袋抽痛异常，仿佛被人用棒子狠狠抡了一下，不，更像是遭尖锐的物品刺入太阳穴并伴随有搅动!"
+        )
+    }
+
+    func testJoinsWhenNextLineStartsWithPunctuationFromSample() {
+        let text = """
+        本身不是收尾，只是一个接续，一个承上启下
+        ，也是另一个方面
+        """
+
+        XCTAssertEqual(
+            TextCleaner.cleanExtractedText(text),
+            "本身不是收尾，只是一个接续，一个承上启下，也是另一个方面"
+        )
+    }
+
+    func testJoinsWhenPunctuationLineHasLeadingAsciiWhitespace() {
+        let text = """
+        本身不是收尾，只是一个接续，一个承上启下
+          ，也是另一个方面
+        """
+
+        XCTAssertEqual(
+            TextCleaner.cleanExtractedText(text),
+            "本身不是收尾，只是一个接续，一个承上启下，也是另一个方面"
+        )
+    }
+
+    func testKeepsLineBreakAfterSentenceEndingBeforeNewIndentedParagraph() {
+        let text = """
+        　　“所有人都会死，包括我。”
+        　　下一段内容继续。
+        """
+
+        XCTAssertEqual(
+            TextCleaner.cleanExtractedText(text),
+            "　　“所有人都会死，包括我。”\n　　下一段内容继续。"
+        )
+    }
+
+    func testKeepsIndentedParagraphStartEvenWhenPreviousLineHasNoEndingPunctuation() {
+        let text = """
+        　　红绯 章一第
+        　　痛!
+        """
+
+        XCTAssertEqual(
+            TextCleaner.cleanExtractedText(text),
+            "　　红绯 章一第\n　　痛!"
+        )
+    }
+
+    func testKeepsPageSeparatorBoundaries() {
+        let text = "上一页最后一行\n\u{000C}\n下一页第一行"
+
+        XCTAssertEqual(TextCleaner.cleanExtractedText(text), text)
+    }
+}


### PR DESCRIPTION
## Summary
- clean wrapped PDF extraction line breaks before writing generated TXT files
- preserve existing TXT opening behavior without cleanup
- add unit tests from Lord of Mysteries extraction samples

Closes #1

## Testing
- plutil -lint PDFReader.xcodeproj/project.pbxproj
- swiftc -parse PDFReader/Services/TextCleaner.swift PDFReader/Services/PDFTextExtractor.swift
- swiftc -module-cache-path /tmp/swift-module-cache PDFReader/Services/TextCleaner.swift /tmp/main.swift -o /tmp/check_text_cleaner && /tmp/check_text_cleaner
- xcodebuild test -project PDFReader.xcodeproj -scheme PDFReader -destination 'platform=iOS Simulator,name=iPhone 16' (fails: active developer directory is CommandLineTools, not Xcode)