### PR TITLE
Preserve chapter heading line breaks in text cleaning

### DIFF
--- a/PDFReader/Services/TextCleaner.swift
+++ b/PDFReader/Services/TextCleaner.swift
@@ -74,6 +74,10 @@ enum TextCleaner {
             return false
         }
 
+        if isChapterHeading(previousLine) {
+            return false
+        }
+
         if startsWithLeadingPunctuation(nextLine) {
             return true
         }
@@ -104,6 +108,26 @@ enum TextCleaner {
         }
 
         return Self.leadingPunctuation.contains(first)
+    }
+
+    private static func isChapterHeading(_ line: String) -> Bool {
+        let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+        guard trimmedLine.hasPrefix("第"), trimmedLine.contains("章") else {
+            return false
+        }
+
+        guard let chapterMarkerIndex = trimmedLine.firstIndex(of: "章") else {
+            return false
+        }
+
+        let numberText = trimmedLine[trimmedLine.index(after: trimmedLine.startIndex)..<chapterMarkerIndex]
+        guard numberText.isEmpty == false else {
+            return false
+        }
+
+        return numberText.allSatisfy { character in
+            character.isNumber || Self.chineseChapterNumberCharacters.contains(character)
+        }
     }
 
     private static func lineForJoining(_ line: String) -> String {
@@ -159,6 +183,10 @@ enum TextCleaner {
 
     private static let sentenceEndingPunctuation = Set<Character>(["。", ".", "！", "!", "？", "?", "…"])
     private static let closingPunctuation = Set<Character>(["”", "\"", "’", "'", "）", ")", "》", ">", "】", "]", "」", "』"])
+    private static let chineseChapterNumberCharacters = Set<Character>([
+        "零", "〇", "一", "二", "三", "四", "五", "六", "七", "八", "九", "十",
+        "百", "千", "两"
+    ])
     private static let leadingPunctuation = Set<Character>([
         "，", ",", "。", ".", "！", "!", "？", "?", "；", ";", "：", ":", "、",
         "”", "\"", "’", "'", "）", ")", "》", ">", "】", "]", "」", "』"

--- a/PDFReaderTests/TextCleanerTests.swift
+++ b/PDFReaderTests/TextCleanerTests.swift
@@ -63,6 +63,23 @@ final class TextCleanerTests: XCTestCase {
         )
     }
 
+    func testKeepsLineBreakAfterChapterHeadingFromIssueThree() {
+        let text = """
+        　　
+        第九十五章 王女
+        不喜欢绰号
+        """
+
+        XCTAssertEqual(
+            TextCleaner.cleanExtractedText(text),
+            """
+            　　
+            第九十五章 王女
+            不喜欢绰号
+            """
+        )
+    }
+
     func testKeepsPageSeparatorBoundaries() {
         let text = "上一页最后一行\n\u{000C}\n下一页第一行"
 


### PR DESCRIPTION
## Summary
- Preserve the newline after detected chapter headings during generated TXT cleaning.
- Add a regression test for the issue #3 sample: `第九十五章 王女` followed by `不喜欢绰号`.

## Verification
- `git diff --check`
- `swiftc -parse PDFReader/Services/TextCleaner.swift`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project PDFReader.xcodeproj -scheme PDFReader -configuration Debug -destination 'id=00008101-001C14D12111001E' -derivedDataPath /tmp/pdfreader-derived build`

Note: XCTest runner launch failed on the connected device before check-in (`Early unexpected exit`, code 74), after the app and test bundle compiled and signed.

Closes #3